### PR TITLE
Change Vercel button link to Deploy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Free Next JS Starter Template
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/templates/Next.js/next-js-saas-website-starter)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?demo-description=A%20minimal%20Next.js%20template%20for%20building%20SaaS%20websites%20with%20only%20the%20essential%20dependencies.&demo-image=%2F%2Fimages.ctfassets.net%2Fe5382hct74si%2F7guUYce8M9UWWL2id1Out%2F432b98af389e3b9605804849a726a258%2Fsaas.png&demo-title=Minimal%20Next.js%20SaaS%20Website%20Starter&demo-url=https%3A%2F%2Fnextjs-saas-starter-template.vercel.app%2F&from=templates&project-name=Minimal%20Next.js%20SaaS%20Website%20Starter&repository-name=next-js-saas-website-starter&repository-url=https%3A%2F%2Fgithub.com%2Ftalhatahir%2Fnextjs-saas-starter-template&skippable-integrations=1)
 
 This is a starter template for a SaaS application built with Next.js. It uses the minimum amount of dependencies and tools to get you started.
 Tailwind CSS is used for styling, and Next Themes is used for dark mode. React Icons is used for icons.


### PR DESCRIPTION
Mistakenly updated the Vercel button link to the Template Marketplace link. This button should open the template deployment directly.